### PR TITLE
chore: Bump `holochain-0.4` dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -884,7 +884,7 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chc-service"
-version = "0.2.0-dev.1"
+version = "0.2.0-dev.2"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "chc-service"
 description = "A local web server that implements the chc (Chain Head Coordinator) interface in Rust"
-version = "0.2.0-dev.2"
+version = "0.2.0-dev.3"
 edition = "2021"
 authors = ["c12i"]
 license = "MIT"
@@ -14,9 +14,9 @@ path = "./src/main.rs"
 anyhow = "1.0.86"
 axum = "0.7.5"
 clap = { version = "4.5.16", features = ["derive"] }
-holochain = { version = "0.4.0", features = ["chc", "test_utils"] }
+holochain = { version = "0.4.2", features = ["chc", "test_utils"] }
 holochain_serialized_bytes = "0.0.55"
-holochain_types = "0.4.0"
+holochain_types = "0.4.2"
 parking_lot = "0.12.3"
 portpicker = "0.1.1"
 rmp-serde = "1.3.0"
@@ -32,7 +32,7 @@ tracing-subscriber = { version = "0.3", features = [
 ] }
 
 [dev-dependencies]
-fixt = "^0.4.0-dev.3"
-holochain_keystore = "0.4.0"
-holochain_nonce = "0.4.0"
+fixt = "^0.4.2"
+holochain_keystore = "0.4.2"
+holochain_nonce = "0.4.2"
 reqwest = "0.11"


### PR DESCRIPTION
Bumping holochain dependencies to latest 0.4 version